### PR TITLE
Job runs improvements

### DIFF
--- a/connect_api/base_connection.py
+++ b/connect_api/base_connection.py
@@ -142,6 +142,12 @@ class BaseConnection(object):
     def _stop_job_run(self, job_run_id):
         self._put('/runs/%d/stop' % job_run_id)
 
+    def _pause_job_run(self, job_run_id):
+        self._put('/runs/%d/pause' % job_run_id)
+
+    def _resume_job_run(self, job_run_id):
+        self._put('/runs/%d/resume' % job_run_id)
+
     def _get_agent_status(self, job_run_id, agent_id):
         return self._get_json('/runs/%d/agents/%d' % (job_run_id, agent_id))
 

--- a/connect_api/models/job_run.py
+++ b/connect_api/models/job_run.py
@@ -32,7 +32,7 @@ class JobRun(BaseModel):
         None
         """
 
-        self._attrs = self._get_job(self.id)
+        self._attrs = self._get_job_run(self.id)
 
     def stop(self):
         """
@@ -43,6 +43,30 @@ class JobRun(BaseModel):
         None
         """
         self._stop_job_run(self.id)
+
+    def pause(self):
+        """
+        Pause job run
+
+        Parameters
+        ----------
+        None
+        """
+        if not self.paused:
+            self._pause_job_run(self.id)
+            self.fetch()
+
+    def resume(self):
+        """
+        Resume job run
+
+        Parameters
+        ----------
+        None
+        """
+        if self.paused:
+            self._resume_job_run(self.id)
+            self.fetch()
 
     @property
     def is_synced(self):
@@ -64,6 +88,18 @@ class JobRun(BaseModel):
         completed = max(self._attrs['size_completed'] - self._attrs['size_total'], 0)
 
         return min(int((completed / expected) * 100), 100)
+
+    @property
+    def active(self):
+        """Is job run active"""
+
+        return self._attrs['active']
+
+    @property
+    def paused(self):
+        """Is job run paused"""
+
+        return self._attrs['status'] == JobRunStatus.PAUSED
 
     # Agent status
     def get_agents_statuses(self):

--- a/connect_api/models/job_run.py
+++ b/connect_api/models/job_run.py
@@ -157,3 +157,9 @@ class JobRun(BaseModel):
         """Download speed"""
 
         return self._attrs['down_speed']
+
+    @property
+    def errors(self):
+        """Errors"""
+
+        return self._attrs['errors']


### PR DESCRIPTION
This pull request enhances the job run management functionality in the `connect_api` module by introducing new methods for pausing and resuming job runs, adding properties to check job run statuses, and fixing a method call. These changes improve the API's flexibility and usability for handling job runs.

### Enhancements to job run management:

* **New methods for pausing and resuming job runs**:
  - Added `_pause_job_run` and `_resume_job_run` methods in `connect_api/base_connection.py` to handle pausing and resuming job runs via the API.
  - Added `pause` and `resume` methods in `connect_api/models/job_run.py` to provide high-level functionality for pausing and resuming job runs with status validation and attribute synchronization.

* **New properties for job run statuses**:
  - Added `active` property to check if a job run is active.
  - Added `paused` property to check if a job run is in the paused state, based on the `JobRunStatus.PAUSED` status.
  - *Added `errors` property in `connect_api/models/job_run.py` to access job run errors directly from the `_attrs` dictionary.

### Bug fix:

* Fixed the method call in the `fetch` method of `connect_api/models/job_run.py` to use `_get_job_run` instead of `_get_job`, ensuring proper attribute fetching.

