### PR TITLE
Fix bug with JobRun's download_percent property

### DIFF
--- a/connect_api/models/job_run.py
+++ b/connect_api/models/job_run.py
@@ -61,7 +61,7 @@ class JobRun(BaseModel):
             return 100
 
         expected = self._attrs['size_total'] * (self._attrs['agents_total'] - 1)
-        completed = max(self._attrs['size_completed'] - self._attrs['size_total'], 0)
+        completed = self._attrs['size_completed']
 
         return min(int((completed / expected) * 100), 100)
 


### PR DESCRIPTION
This pull request includes a change to the `download_percent` method in the `connect_api/models/job_run.py` file.

I had noticed that since switching to this method, my progress always stayed at 0%.

Upon closer inspection, I noticed that unless `self._attrs['size_completed']` is greater than `self._attrs['size_total']`, the line `max(self._attrs['size_completed'] - self._attrs['size_total'], 0)` will always be 0, as the portion `self._attrs['size_completed'] - self._attrs['size_total']` can only be negative.

**disclaimer:** I don't fully understand how the number of agents affects the numbers used here.
My own version before I switched to using this property was using `self._attrs['size_completed'] / self._attrs['size_total'] * 100` and was ignoring the number of agents, while I notice this function tried to take it into account for the `expected` variable.

I could use a verification from someone more familiar with the rest API to ensure this is indeed the correct calculation.
Also, I wonder what the `progress` attribute is intended to represent, the docs say: `Job run transfer progress. Not available for script job` but the values I'm seeing are nowhere close to a completion percentage.